### PR TITLE
Enable Sphinx rendering RST tables in Markdown

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ from typing import List
 
 import patchy
 from click import secho, style
+from recommonmark.transform import AutoStructify
 from sphinx.ext.autosummary.generate import generate_autosummary_docs
 
 from causalnex import __version__ as release
@@ -390,7 +391,9 @@ def _prepare_build_dir(app, config):
     shutil.rmtree(str(build_root / "api_docs"))
     shutil.rmtree(str(build_out), ignore_errors=True)
     copy_tree(str(build_root / "css"), str(build_out / "_static" / "css"))
-    copy_tree(str(build_root / "04_user_guide/images"), str(build_out / "04_user_guide"))
+    copy_tree(
+        str(build_root / "04_user_guide/images"), str(build_out / "04_user_guide")
+    )
     shutil.rmtree(str(build_root / "css"))
 
 
@@ -407,7 +410,10 @@ def setup(app):
     app.add_stylesheet("css/causalnex.css")
 
     # when using nbsphinx, to allow mathjax render properly
-    app.config._raw_config.pop('mathjax_config')
+    app.config._raw_config.pop("mathjax_config")
+    # enable rendering RST tables in Markdown
+    app.add_config_value("recommonmark_config", {"enable_eval_rst": True}, True)
+    app.add_transform(AutoStructify)
 
 
 def fix_module_paths():


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Why was this PR created?


When you click "Edit on Github" button in the ReadtheDocs, you get a 404 error. This is because the redirected link is still rst files. So I changed the Sphinx rendering part to convert it into markdown

![Screenshot 2020-01-30 at 11 44 12](https://user-images.githubusercontent.com/8097799/73447126-fe8a9e80-4355-11ea-81b9-02390a30e5f7.png)

It needs an update in ReadtheDocs side as well. 

## How has this been tested?
What testing strategies have you used?

N/A
## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
