### PR TITLE
adding `black` package to test requirements

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+black>=19.10b0
 flake8>=3.5,<4.0
 isort>=4.3.16, <5.0
 mock>=2.0.0,<3.0


### PR DESCRIPTION
## Notice

- [] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
I proceeded as follows:
-  cloned causalnex repo
- set a new anaconda environment (python 3.6)
- installed test requirements (`make install-test-requirements`)
- run `make test` (all passed)
- run `make lint` Failed, with the following message:

<img width="1433" alt="Screenshot 2020-04-24 at 1 10 41 PM" src="https://user-images.githubusercontent.com/57528979/80178565-1ad66880-8631-11ea-83d3-d31fe9f4c391.png">

I updated `test_requirements.txt` with black, and all passed.

Note: I have not updated `RELEASE.md` because this does not affect the package usage 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
