### PR TITLE
Fix: pygraphviz gradient string can not be rendered correctly on Windows

### DIFF
--- a/causalnex/plots/display.py
+++ b/causalnex/plots/display.py
@@ -25,7 +25,7 @@
 #
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Methods to display styled pygraphgiz plots."""
+"""Methods to display styled pygraphviz plots."""
 
 import io
 from typing import Any, Tuple
@@ -56,7 +56,7 @@ def display_plot_ipython(viz: AGraph, prog: str = "neato") -> Image:
     Args:
         viz: pygraphviz object to render.
 
-        prog: The graph layout. Avaliable are:
+        prog: The graph layout. Available are:
         dot, neato, fdp, sfdp, twopi and circo
 
     Returns:
@@ -84,7 +84,7 @@ def display_plot_mpl(
     Args:
         viz: pygraphviz object to render.
 
-        prog: The graph layout. Avaliable are:
+        prog: The graph layout. Available are:
         dot, neato, fdp, sfdp, twopi and circo
 
         ax: Optional matplotlib axes to plot on.

--- a/causalnex/plots/plots.py
+++ b/causalnex/plots/plots.py
@@ -26,22 +26,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Plot Methods."""
+import platform
 import re
 from collections import namedtuple
 from copy import deepcopy
 from typing import Dict, Tuple
-import platform
+
 import networkx as nx
 
 
 def plot_structure(
-        sm: nx.DiGraph,
-        prog: str = "neato",
-        all_node_attributes: Dict[str, str] = None,
-        all_edge_attributes: Dict[str, str] = None,
-        node_attributes: Dict[str, Dict[str, str]] = None,
-        edge_attributes: Dict[Tuple[str, str], Dict[str, str]] = None,
-        graph_attributes: Dict[str, str] = None,
+    sm: nx.DiGraph,
+    prog: str = "neato",
+    all_node_attributes: Dict[str, str] = None,
+    all_edge_attributes: Dict[str, str] = None,
+    node_attributes: Dict[str, Dict[str, str]] = None,
+    edge_attributes: Dict[Tuple[str, str], Dict[str, str]] = None,
+    graph_attributes: Dict[str, str] = None,
 ):
     """
     Plot a `StructureModel` using pygraphviz.
@@ -190,11 +191,11 @@ def color_gradient_string(from_color: str, to_color: str, steps: int) -> str:
 
 
 def _add_attributes(
-        sm: nx.DiGraph,
-        all_node_attributes: Dict[str, str] = None,
-        all_edge_attributes: Dict[str, str] = None,
-        node_attributes: Dict[str, Dict[str, str]] = None,
-        edge_attributes: Dict[str, Dict[str, str]] = None,
+    sm: nx.DiGraph,
+    all_node_attributes: Dict[str, str] = None,
+    all_edge_attributes: Dict[str, str] = None,
+    node_attributes: Dict[str, Dict[str, str]] = None,
+    edge_attributes: Dict[str, Dict[str, str]] = None,
 ) -> nx.DiGraph:
     _sm = deepcopy(sm)
 

--- a/causalnex/plots/plots.py
+++ b/causalnex/plots/plots.py
@@ -26,8 +26,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Plot Methods."""
-import platform
 import re
+import sys
 from collections import namedtuple
 from copy import deepcopy
 from typing import Dict, Tuple
@@ -158,11 +158,9 @@ def color_gradient_string(from_color: str, to_color: str, steps: int) -> str:
     Returns:
         a pygraphviz color gradient string
     """
-    sys = platform.system()
 
-    if sys == "Windows":
-        if steps > 7:
-            steps = 7
+    if sys.platform == "win32" and steps > 7:
+        steps = 7
 
     color_regex = re.compile(
         r"(#)([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})*"

--- a/causalnex/plots/plots.py
+++ b/causalnex/plots/plots.py
@@ -30,23 +30,23 @@ import re
 from collections import namedtuple
 from copy import deepcopy
 from typing import Dict, Tuple
-
+import platform
 import networkx as nx
 
 
 def plot_structure(
-    sm: nx.DiGraph,
-    prog: str = "neato",
-    all_node_attributes: Dict[str, str] = None,
-    all_edge_attributes: Dict[str, str] = None,
-    node_attributes: Dict[str, Dict[str, str]] = None,
-    edge_attributes: Dict[Tuple[str, str], Dict[str, str]] = None,
-    graph_attributes: Dict[str, str] = None,
+        sm: nx.DiGraph,
+        prog: str = "neato",
+        all_node_attributes: Dict[str, str] = None,
+        all_edge_attributes: Dict[str, str] = None,
+        node_attributes: Dict[str, Dict[str, str]] = None,
+        edge_attributes: Dict[Tuple[str, str], Dict[str, str]] = None,
+        graph_attributes: Dict[str, str] = None,
 ):
     """
     Plot a `StructureModel` using pygraphviz.
 
-    Return a pygraphviz graph from a StructureModel. The pygraphgiz graph
+    Return a pygraphviz graph from a StructureModel. The pygraphviz graph
     is decorated and laid out so that it can be plotted easily.
 
     Default node, edge, and graph attributes are provided to style and layout
@@ -88,13 +88,13 @@ def plot_structure(
         sm: structure to plot
         prog: Name of Graphviz layout program
         all_node_attributes: attributes to apply to all nodes
-        all_edge_attributes: attrinbutes to apply to all edges
+        all_edge_attributes: attributes to apply to all edges
         node_attributes: attributes to apply to specific nodes
         edge_attributes: attributes to apply to specific edges
         graph_attributes: attributes to apply to the graph
 
     Returns:
-        a styled pygraphgiz graph that can be rendered as an image
+        a styled pygraphviz graph that can be rendered as an image
 
     Raises:
         Warning: Suggests mitigation strategies when ``pygraphviz`` is not installed.
@@ -135,7 +135,7 @@ def plot_structure(
 
 def color_gradient_string(from_color: str, to_color: str, steps: int) -> str:
     """
-    Create a pygraphgiz compatible color gradient string.
+    Create a pygraphviz compatible color gradient string.
 
     This string can be used when setting colors for nodes,
     edges, and graph attributes.
@@ -157,6 +157,11 @@ def color_gradient_string(from_color: str, to_color: str, steps: int) -> str:
     Returns:
         a pygraphviz color gradient string
     """
+    sys = platform.system()
+
+    if sys == "Windows":
+        if steps > 7:
+            steps = 7
 
     color_regex = re.compile(
         r"(#)([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})*"
@@ -185,11 +190,11 @@ def color_gradient_string(from_color: str, to_color: str, steps: int) -> str:
 
 
 def _add_attributes(
-    sm: nx.DiGraph,
-    all_node_attributes: Dict[str, str] = None,
-    all_edge_attributes: Dict[str, str] = None,
-    node_attributes: Dict[str, Dict[str, str]] = None,
-    edge_attributes: Dict[str, Dict[str, str]] = None,
+        sm: nx.DiGraph,
+        all_node_attributes: Dict[str, str] = None,
+        all_edge_attributes: Dict[str, str] = None,
+        node_attributes: Dict[str, Dict[str, str]] = None,
+        edge_attributes: Dict[str, Dict[str, str]] = None,
 ) -> nx.DiGraph:
     _sm = deepcopy(sm)
 
@@ -225,7 +230,7 @@ def _add_attributes(
 GRAPH_STYLE = {
     "bgcolor": "#001521",
     "fontcolor": "#FFFFFFD9",
-    "fontname": "Helvetica",
+    "fontname": "Helvetica,Arial,sans-serif",
     "splines": True,
     "overlap": "scale",
     "scale": 2.0,
@@ -238,7 +243,7 @@ _style = namedtuple("Style", ["WEAK", "NORMAL", "STRONG"])
 NODE_STYLE = _style(
     {
         "fontcolor": "#FFFFFF8c",
-        "fontname": "Helvetica",
+        "fontname": "Helvetica,Arial,sans-serif",
         "shape": "circle",
         "fixedsize": True,
         "style": "filled",
@@ -250,7 +255,7 @@ NODE_STYLE = _style(
     },
     {
         "fontcolor": "#FFFFFFD9",
-        "fontname": "Helvetica",
+        "fontname": "Helvetica,Arial,sans-serif",
         "shape": "circle",
         "fixedsize": True,
         "style": "filled",
@@ -262,7 +267,7 @@ NODE_STYLE = _style(
     },
     {
         "fontcolor": "#4a90e2",
-        "fontname": "Helvetica",
+        "fontname": "Helvetica,Arial,sans-serif",
         "shape": "circle",
         "fixedsize": True,
         "style": "filled",

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -191,16 +191,35 @@ class TestColorGradientString:
         s = color_gradient_string("#ffffff33", "#ffffffaa", 1)
         assert s.endswith("#ffffffaa;0.50")
 
+    @patch("sys.platform", "linux")
     def test_correct_num_steps(self):
         """string should have the correct number of steps"""
         for steps in range(1, 10):
             s = color_gradient_string("#ffffff33", "#ffffffaa", steps)
             assert s.count(":") == steps
 
+    @patch("sys.platform", "linux")
     def test_expected_string(self):
         """should produce the expected reference example"""
         s = color_gradient_string("#00000000", "#99999999", 9)
         expected = ":".join(["#" + str(i) * 8 + ";0.10" for i in range(10)])
+        assert s == expected
+
+    @patch("sys.platform", "win32")
+    def test_correct_num_steps_on_windows(self):
+        """string should have the correct number of steps"""
+        for steps in range(1, 10):
+            s = color_gradient_string("#ffffff33", "#ffffffaa", steps)
+            if steps > 7:
+                assert s.count(":") == 7
+            else:
+                assert s.count(":") == steps
+
+    @patch("sys.platform", "win32")
+    def test_expected_string_on_windows(self):
+        """should produce the expected reference example"""
+        s = color_gradient_string("#00000000", "#77777777", 9)
+        expected = ":".join(["#" + str(i) * 8 + ";0.12" for i in range(8)])
         assert s == expected
 
 


### PR DESCRIPTION
When I tried to visualize a model on Windows using `plot_structure` , I got black colored edges with shifted position, as the image below:

![output](https://user-images.githubusercontent.com/2208908/191472961-31096c39-eeaf-4e77-a21a-9a1458724b90.png)

Well, I think this is a compatibility issue from graphviz on Windows. If I shorten the gradient string, it can be rendered perfectly. So I cut down the `steps`, make sure it‘s never greater than 7. 

This is the out plotting after fixing:
 
![output2](https://user-images.githubusercontent.com/2208908/191474322-982d22c1-7bcf-4cad-bf4e-3d58a21bcd99.png)
